### PR TITLE
fix: Include only src in the build output.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "outDir": "./dist",
     "baseUrl": "./src"
   },
-  "include": ["./**/*"],
+  "include": ["./src/*"],
   "exclude": ["./node_modules/**/*"]
 }


### PR DESCRIPTION
This fixes missing typescript definitions in the build output (package.json points to dist/index.d.ts and the file is not there after building the project). Plus it probably doesn't make sense to include tests in the build anyway.